### PR TITLE
Update Gatsby SSR and Gatsby Browser APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-asset-path",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Gatsby plugin that moves JS and CSS files and static folder to a custom folder",
   "main": "index.js",
   "scripts": {

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -4,4 +4,4 @@ import createHistory from "history/createBrowserHistory"
  * Removes prefix from paths once links are clicked on by removing the basename
  * @see {@link https://github.com/gatsbyjs/gatsby/blob/v2.0.0-alpha.20/packages/gatsby/cache-dir/history.js#L10}
  */
-export const replaceHistory = () => createHistory()
+export const replaceComponentRenderer = () => createHistory()

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -7,6 +7,6 @@ import { StaticRouter } from "react-router-dom"
  * @see {@link https://next.gatsbyjs.org/docs/ssr-apis/#replaceStaticRouterComponent}
  * @see {@link https://github.com/gatsbyjs/gatsby/blob/v2.0.0-alpha.20/packages/gatsby/cache-dir/static-entry.js#L114}
  */
-export const replaceStaticRouterComponent = () => {
+export const replaceRenderer = () => {
   return ({ basename, ...props }) => <StaticRouter {...props} />
 }


### PR DESCRIPTION
#2 

The new version of Gatsby changed the API. When I build the project, that messages shows on log:
```
See https://www.gatsbyjs.org/docs/browser-apis/ for the list of Gatsby Browser APIs
- The plugin "gatsby-plugin-asset-path@0.1.3" is exporting a variable named "replaceHistory" which isn't an API.

See https://www.gatsbyjs.org/docs/ssr-apis/ for the list of Gatsby SSR APIs
- The plugin "gatsby-plugin-asset-path@0.1.3" is exporting a variable named "replaceStaticRouterComponent" which isn't an API.
```
I changed `replaceHistory` to `replaceComponentRenderer` on `gatsby-brower` and `replaceStaticRouterComponent` to `replaceRenderer` on `gatsby-ssr`