### PR TITLE
Adds additionalFiles option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,23 @@ Stops Webpack from generating the .js.map files
   ];
 }
 ```
+
+### additionalFiles
+
+Default: []
+
+Additional files to move to the asset directory.
+
+```javascript
+// Your gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: "gatsby-plugin-asset-path",
+      options: {
+        additionalFiles: ['example.txt'],
+      },
+    },
+  ];
+}
+```

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,7 +23,7 @@ export const onCreateWebpackConfig = (
  * Moves all js and css files into timestamp-named folder
  * @see {@link https://next.gatsbyjs.org/docs/node-apis/#onPostBuild}
  */
-export const onPostBuild = async ({ pathPrefix }) => {
+export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
   const publicFolder = "./public";
   const assetFolder = path.join(publicFolder, `.${pathPrefix}`);
 
@@ -47,6 +47,8 @@ export const onPostBuild = async ({ pathPrefix }) => {
       }
     }),
   );
+
+  await Promise.all(additionalFiles.map((file) => move(file)));
 
   // Move statics data and icons
   await Promise.all(["static", "icons"].map(move));


### PR DESCRIPTION
Adds `additionalFiles` option. This will allow developers to tell the plugin what additional files to move to the asset path.

This feature alone is helpful, but my suggestion is also to use this to solve the following issues:
- #6 - currently, the `sitemap.xml` is hard coded and you need such a file to use this plugin. This could instead be passed to `addionalFiles` for those who have such a file and wants it in their asset directory.
- #12 - instead of assuming that everyone wants to move their manifest file to the asset directory, which by the way Gatsby does not do by default, you can pass the such a file to `additionalFiles`.