### PR TITLE
Using additional files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Stops Webpack from generating the .js.map files
 
 ### additionalFiles
 
-Default: []
+Default: `[]`
 
 Additional files to move to the asset directory.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Move all of your JS and CSS build files, as well as the static folder into a sub
 
 Use `assetPrefix` instead of `pathPrefix`
 
+## Breaking change in v2
+
+- A sitemap is no longer required
+- A webmanifest is no longer required
+
+The above two files were hard coded into this plugin in earlier versions. Now you can instead use the new `additionalFiles` option to pass whatever files you want to move to the asset path. To get the same behavior as v1, use the following options:
+
+```javascript
+options: {
+  additionalFiles: ["manifest.webmanifest", "sitemap.xml"],
+},
+```
+
 ## Our use case
 
 Gatsby by default will generate all of the assets and put them directly at the root level:

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -53,6 +53,6 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
   // Move statics data and icons
   await Promise.all(["static", "icons"].map(move));
 
-  // Copy page data and sitemap
-  await Promise.all(["page-data", "sitemap.xml"].map(copy));
+  // Copy page data
+  await Promise.all(["page-data"].map(copy));
 };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -38,11 +38,11 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
     return fs.move(currentPath, newPath);
   };
 
-  // Move css,js and webmanifest files
+  // Move css and js
   const files = fs.readdirSync(publicFolder);
   await Promise.all(
     files.map((file) => {
-      if (/.*\.(js|css|webmanifest)$/.test(file)) {
+      if (/.*\.(js|css)$/.test(file)) {
         return move(file);
       }
     }),


### PR DESCRIPTION
- Fixes #6 removed hard coded `sitemap.yml`. Use the new option `additionalFiles` instead. Though: note that the sitemap was copied rather than moved before. Is this ok? Why do someone need to copy the sitemap rather than moving it? Why have a sitemap in both the asset path AND the root path?

- Fixes #12 removes hard coded `manifest` file. Instead use the `additionalFiles` option.

This PR is breaking! If it is merged, please bump to new major version!