### PR TITLE
Renames option additionalFiles -> additionalPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Use `assetPrefix` instead of `pathPrefix`
 - A sitemap is no longer required
 - A webmanifest is no longer required
 
-The above two files were hard coded into this plugin in earlier versions. Now you can instead use the new `additionalPaths` option to pass whatever files you want to move to the asset path. To get the same behavior as v1, use the following options:
+The above two files were hard coded into this plugin in earlier versions. If you still want to move these files to the assets folder, use the new `additionalPaths` option, see below for more information on the option. To get the same behavior as v1, use the following options:
 
 ```javascript
 options: {
   additionalPaths: ["manifest.webmanifest", "sitemap.xml"],
 },
 ```
+
+Also note that `sitemap.xml` and the `page-data` folder was copied to assets folder before, now they are moved just as all other files this plugin handles.
 
 ## Our use case
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Stops Webpack from generating the .js.map files
 }
 ```
 
-### additionalFiles
+### additionalPaths
 
 Default: []
 
-Additional files to move to the asset directory.
+Additional paths to files/folders that should be moved to the asset directory.
 
 ```javascript
 // Your gatsby-config.js
@@ -129,7 +129,7 @@ Additional files to move to the asset directory.
     {
       resolve: "gatsby-plugin-asset-path",
       options: {
-        additionalFiles: ['example.txt'],
+        additionalPaths: ['example.txt', 'foo/example.txt', 'bar/'],
       },
     },
   ];

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ options: {
 },
 ```
 
-Also note that `sitemap.xml` and the `page-data` folder was copied to assets folder before, now they are moved just as all other files this plugin handles.
+Also note that `sitemap.xml` and the `page-data` folder were copied to assets folder before, now they are moved just as all other files this plugin handles.
 
 ## Our use case
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Use `assetPrefix` instead of `pathPrefix`
 - A sitemap is no longer required
 - A webmanifest is no longer required
 
-The above two files were hard coded into this plugin in earlier versions. Now you can instead use the new `additionalFiles` option to pass whatever files you want to move to the asset path. To get the same behavior as v1, use the following options:
+The above two files were hard coded into this plugin in earlier versions. Now you can instead use the new `additionalPaths` option to pass whatever files you want to move to the asset path. To get the same behavior as v1, use the following options:
 
 ```javascript
 options: {
-  additionalFiles: ["manifest.webmanifest", "sitemap.xml"],
+  additionalPaths: ["manifest.webmanifest", "sitemap.xml"],
 },
 ```
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,7 +23,7 @@ export const onCreateWebpackConfig = (
  * Moves all js and css files into timestamp-named folder
  * @see {@link https://next.gatsbyjs.org/docs/node-apis/#onPostBuild}
  */
-export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
+export const onPostBuild = async ({ pathPrefix }, { additionalPaths = [] }) => {
   const publicFolder = "./public";
   const assetFolder = path.join(publicFolder, `.${pathPrefix}`);
 
@@ -48,7 +48,7 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
     }),
   );
 
-  await Promise.all(additionalFiles.map((file) => move(file)));
+  await Promise.all(additionalPaths.map((file) => move(file)));
 
   // Move statics data and icons
   await Promise.all(["static", "icons"].map(move));

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -40,7 +40,7 @@ export const onPostBuild = async ({ pathPrefix }, { additionalPaths = [] }) => {
   const directories = ["static", "icons", "page-data"];
   const thingsToMove = directories
     .concat(filesInPublicFolder)
-    .concat(additionalFiles);
+    .concat(additionalPaths);
 
   // Move files and directories
   await Promise.all(thingsToMove.map(move));


### PR DESCRIPTION
The naming of `additionalFiles` is misleading since it also accepts folders and paths to files in sub directories. This PR changes the name to `additionalPaths` to make it more generic.

If we merge #18 first, I can update the references to `additionalFiles` from that PR before merging this PR.