### PR TITLE
Moves page-data instead of copying it

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -27,11 +27,6 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
   const publicFolder = "./public";
   const assetFolder = path.join(publicFolder, `.${pathPrefix}`);
 
-  const copy = (fileOrFolder) => {
-    const currentPath = path.join(publicFolder, fileOrFolder);
-    const newPath = path.join(assetFolder, fileOrFolder);
-    return fs.copy(currentPath, newPath);
-  };
   const move = (fileOrFolder) => {
     const currentPath = path.join(publicFolder, fileOrFolder);
     const newPath = path.join(assetFolder, fileOrFolder);

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -50,9 +50,6 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
 
   await Promise.all(additionalFiles.map((file) => move(file)));
 
-  // Move statics data and icons
-  await Promise.all(["static", "icons"].map(move));
-
-  // Copy page data
-  await Promise.all(["page-data"].map(copy));
+  // Move statics data, icons and page data
+  await Promise.all(["static", "icons", "page-data"].map(move));
 };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -33,18 +33,15 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
     return fs.move(currentPath, newPath);
   };
 
-  // Move css and js
-  const files = fs.readdirSync(publicFolder);
-  await Promise.all(
-    files.map((file) => {
-      if (/.*\.(js|css)$/.test(file)) {
-        return move(file);
-      }
-    }),
-  );
+  const filterFilesIn = (folder) =>
+    fs.readdirSync(folder).filter((file) => /.*\.(js|css)$/.test(file));
 
-  await Promise.all(additionalFiles.map((file) => move(file)));
+  const filesInPublicFolder = filterFilesIn(publicFolder);
+  const directories = ["static", "icons", "page-data"];
+  const thingsToMove = directories
+    .concat(filesInPublicFolder)
+    .concat(additionalFiles);
 
-  // Move statics data, icons and page data
-  await Promise.all(["static", "icons", "page-data"].map(move));
+  // Move files and directories
+  await Promise.all(thingsToMove.map(move));
 };


### PR DESCRIPTION
Moves `page-data` instead of copying it. Gatsby uses `assetsPrefix` for `page-data`, so I don't know why it is copied at all...