### PR TITLE
Allow configuring of default folder and filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Stops Webpack from generating the .js.map files
 }
 ```
 
-### additionalPaths
+### paths
 
-Default: `[]`
+Default: `["static", "icons", "page-data"]`
 
-Additional paths to files/folders that should be moved to the asset directory.
+The paths of files/folders to be moved to the asset directory.
 
 ```javascript
 // Your gatsby-config.js
@@ -144,7 +144,27 @@ Additional paths to files/folders that should be moved to the asset directory.
     {
       resolve: "gatsby-plugin-asset-path",
       options: {
-        additionalPaths: ['example.txt', 'foo/example.txt', 'bar/'],
+        paths: ["static"]
+      },
+    },
+  ];
+}
+```
+
+### fileTypes
+
+Default: `["js", "css"]`
+
+The types of files in the root `publicFolder` to be moved to the asset directory.
+
+```javascript
+// Your gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: "gatsby-plugin-asset-path",
+      options: {
+        fileTypes: ['js', 'map', 'css'],
       },
     },
   ];

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -23,7 +23,14 @@ export const onCreateWebpackConfig = (
  * Moves all js and css files into timestamp-named folder
  * @see {@link https://next.gatsbyjs.org/docs/node-apis/#onPostBuild}
  */
-export const onPostBuild = async ({ pathPrefix }, { additionalPaths = [] }) => {
+export const onPostBuild = async (
+  { pathPrefix },
+  {
+    additionalPaths = [], // depricated argument to prevent breaking change
+    paths = ["static", "icons", "page-data"],
+    fileTypes = ["js", "css"],
+  },
+) => {
   const publicFolder = "./public";
   const assetFolder = path.join(publicFolder, `.${pathPrefix}`);
 
@@ -33,14 +40,15 @@ export const onPostBuild = async ({ pathPrefix }, { additionalPaths = [] }) => {
     return fs.move(currentPath, newPath);
   };
 
+  const filesExtensions = fileTypes.join("|");
+  const filesRegex = RegExp(`.*.(${filesExtensions})$`);
   const filterFilesIn = (folder) =>
-    fs.readdirSync(folder).filter((file) => /.*\.(js|css)$/.test(file));
+    fs.readdirSync(folder).filter((file) => filesRegex.test(file));
 
   const filesInPublicFolder = filterFilesIn(publicFolder);
-  const directories = ["static", "icons", "page-data"];
-  const thingsToMove = directories
-    .concat(filesInPublicFolder)
-    .concat(additionalPaths);
+  const thingsToMove = paths
+    .concat(additionalPaths)
+    .concat(filesInPublicFolder);
 
   // Move files and directories
   await Promise.all(thingsToMove.map(move));


### PR DESCRIPTION
- Added `directories` setting to override which folders to move
- Added `fileTypes` setting to specify which file types in the public folder to move, currently only moves `css` and `js` files.

Currently the plugin throws an error if an `icon` folder doesn't exist.
Also needed the map files moving along with the js files as they were still in the root after the js files were moved.