### PR TITLE
fix: prevent crash on copy and move action when file does not exits

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -30,12 +30,26 @@ export const onPostBuild = async ({ pathPrefix }, { additionalFiles = [] }) => {
   const copy = (fileOrFolder) => {
     const currentPath = path.join(publicFolder, fileOrFolder);
     const newPath = path.join(assetFolder, fileOrFolder);
-    return fs.copy(currentPath, newPath);
+    try {
+      if (fs.existsSync(currentPath)) {
+        return fs.copy(currentPath, newPath);
+      }
+    } catch (err) {
+      console.error(err);
+      return Promise.resolve();
+    }
   };
   const move = (fileOrFolder) => {
     const currentPath = path.join(publicFolder, fileOrFolder);
     const newPath = path.join(assetFolder, fileOrFolder);
-    return fs.move(currentPath, newPath);
+    try {
+      if (fs.existsSync(currentPath)) {
+        return fs.move(currentPath, newPath);
+      }
+    } catch (err) {
+      console.error(err);
+      return Promise.resolve();
+    }
   };
 
   // Move css,js and webmanifest files


### PR DESCRIPTION
⚠️ Merge request is based on v1.10. - Master is not up to date.

# Step to reproduce
Since I do not have `icons` folder neither `sitemap.xml` the plugin was crashing because there is no check before copy or move attempt.

## Output when running `yarn gatsby build`
```sh
success Building production JavaScript and CSS bundles - 14.783s
success run queries - 15.337s - 18/18 1.17/s
success Building static HTML for pages - 2.640s - 5/5 1.89/s

 ERROR #11321  PLUGIN

"gatsby-plugin-asset-path" threw an error while running the onPostBuild lifecycle:

ENOENT: no such file or directory, stat 'public/sitemap.xml'



  Error: ENOENT: no such file or directory, stat 'public/sitemap.xml'

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```