### PR TITLE
WIP: Adds copyAssets option, relates to #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ The types of files in the root `publicFolder` to be copied to the asset director
 }
 ```
 
+### copyAssets
+
+Default: true
+
+After v3, the default behavior is to copy all assets. This is due to problems with Gatsby cache described in https://github.com/madecomfy/gatsby-plugin-asset-path/issues/41. If you know what you are doing and you still want to move your assets (at least most of them, some needs to be copied still), set `copyAssets` to `false` and your assets will be moved instead.
+
+```javascript
+// Your gatsby-config.js
+{
+  plugins: [
+    {
+      resolve: "gatsby-plugin-asset-path",
+      options: {
+        copyAssets: false, // move assets instead of copy
+      },
+    },
+  ];
+}
+```
+
 # DEPLOY
 
 Update version in package.json then release via github releases with same tag #!


### PR DESCRIPTION
**Work in progress... This code is not tested yet.**

This is a first attempt to add a new `copyAssets` option, which you can set to `false` and then get your assets moved instead of copied. Sometimes, that's what you want.

I've asked Gatsby about more insights regarding how the cache system works in https://github.com/madecomfy/gatsby-plugin-asset-path/issues/31. Let's hope we get an enlightening answer there :)